### PR TITLE
switching from CL/sycl to sycl/sycl

### DIFF
--- a/9_sycl_of_hell/0_tiny_sycl_info.cpp
+++ b/9_sycl_of_hell/0_tiny_sycl_info.cpp
@@ -1,7 +1,7 @@
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <vector>
 
-namespace sycl = cl::sycl;
+
 
 int main() {
 

--- a/9_sycl_of_hell/1_my_first_kernel.cpp
+++ b/9_sycl_of_hell/1_my_first_kernel.cpp
@@ -2,7 +2,7 @@
 #include <cstdint>
 
 // Maybe in the futur sycl will not be in the 'cl' namespace
-namespace sycl = cl::sycl;
+
 
 int main() {
   // Selectors determine which device kernels will be dispatched to.

--- a/9_sycl_of_hell/2_parallel_for.cpp
+++ b/9_sycl_of_hell/2_parallel_for.cpp
@@ -1,7 +1,7 @@
 #include "argparse.hpp"
 #include <CL/sycl.hpp>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/3_nd_range.cpp
+++ b/9_sycl_of_hell/3_nd_range.cpp
@@ -1,7 +1,7 @@
 #include "argparse.hpp"
 #include <CL/sycl.hpp>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/4_buffer.cpp
+++ b/9_sycl_of_hell/4_buffer.cpp
@@ -2,7 +2,7 @@
 #include <CL/sycl.hpp>
 #include <vector>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/5_copy_device_to_host.cpp
+++ b/9_sycl_of_hell/5_copy_device_to_host.cpp
@@ -1,7 +1,7 @@
 #include "argparse.hpp"
 #include <CL/sycl.hpp>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/6_error_handling.cpp
+++ b/9_sycl_of_hell/6_error_handling.cpp
@@ -1,7 +1,7 @@
 #include "argparse.hpp"
 #include <CL/sycl.hpp>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/7_buffer_usm.cpp
+++ b/9_sycl_of_hell/7_buffer_usm.cpp
@@ -1,7 +1,7 @@
 #include "argparse.hpp"
 #include <CL/sycl.hpp>
 
-namespace sycl = cl::sycl;
+
 
 int main(int argc, char **argv) {
 

--- a/9_sycl_of_hell/8_event.cpp
+++ b/9_sycl_of_hell/8_event.cpp
@@ -1,5 +1,4 @@
-#include <CL/sycl.hpp>
-namespace sycl = cl::sycl;
+#include <sycl/sycl.hpp>
 
 int main() {
   // If one use event to use profiling, you need to enable your queue for that
@@ -19,14 +18,14 @@ int main() {
   // The queue submition return an event,
   // That we can use for synchronizing kernel submision, or like in this example,
   // or gather proffiling information
-  cl::sycl::event e0 = Q.submit([&](sycl::handler &cgh) {
+  sycl::event e0 = Q.submit([&](sycl::handler &cgh) {
     sycl::stream sout(1024, 256, cgh);
     cgh.single_task<class hello_world>([=]() {
        sout << "Hello, World 0!" << sycl::endl;
     }); 
   }); 
 
-  cl::sycl::event e1 = Q.submit([&](sycl::handler &cgh) {
+  sycl::event e1 = Q.submit([&](sycl::handler &cgh) {
     //This kernel will wait that e0 finish before being submited
     // Without it, because Queue are out-of-order by default, the order was non deterministic
     cgh.depends_on(e0);

--- a/9_sycl_of_hell/8_event.cpp
+++ b/9_sycl_of_hell/8_event.cpp
@@ -20,7 +20,7 @@ int main() {
   // or gather proffiling information
   sycl::event e0 = Q.submit([&](sycl::handler &cgh) {
     sycl::stream sout(1024, 256, cgh);
-    cgh.single_task<class hello_world>([=]() {
+    cgh.single_task([=]() {
        sout << "Hello, World 0!" << sycl::endl;
     }); 
   }); 
@@ -30,7 +30,7 @@ int main() {
     // Without it, because Queue are out-of-order by default, the order was non deterministic
     cgh.depends_on(e0);
     sycl::stream sout(1024, 256, cgh);
-    cgh.single_task<class hello_world>([=]() {
+    cgh.single_task([=]() {
        sout << "Hello, World 1!" << sycl::endl;
     });
   });


### PR DESCRIPTION
- Switching from CL/sycl to sycl/sycl in the hedaders 
- Removing references to `::cl::sycl` since by Sect. 4.3 in https://www.khronos.org/registry/SYCL/specs/sycl-2020/pdf/sycl-2020.pdf , this is no longer needed. 
- Removed class names in 8_event.cpp since there was a compiler error `error: redefinition of 'KernelInfo<hello_world>'`.