### PR TITLE
Updating included headers

### DIFF
--- a/9_sycl_of_hell/1_my_first_kernel.cpp
+++ b/9_sycl_of_hell/1_my_first_kernel.cpp
@@ -1,4 +1,4 @@
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cstdint>
 
 // Maybe in the futur sycl will not be in the 'cl' namespace

--- a/9_sycl_of_hell/1_my_first_kernel.cpp
+++ b/9_sycl_of_hell/1_my_first_kernel.cpp
@@ -1,7 +1,6 @@
 #include <sycl/sycl.hpp>
 #include <cstdint>
 
-// Maybe in the futur sycl will not be in the 'cl' namespace
 
 
 int main() {

--- a/9_sycl_of_hell/2_parallel_for.cpp
+++ b/9_sycl_of_hell/2_parallel_for.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 
 

--- a/9_sycl_of_hell/3_nd_range.cpp
+++ b/9_sycl_of_hell/3_nd_range.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 
 

--- a/9_sycl_of_hell/4_buffer.cpp
+++ b/9_sycl_of_hell/4_buffer.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <vector>
 
 

--- a/9_sycl_of_hell/5_copy_device_to_host.cpp
+++ b/9_sycl_of_hell/5_copy_device_to_host.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 
 

--- a/9_sycl_of_hell/6_error_handling.cpp
+++ b/9_sycl_of_hell/6_error_handling.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 
 

--- a/9_sycl_of_hell/7_buffer_usm.cpp
+++ b/9_sycl_of_hell/7_buffer_usm.cpp
@@ -1,5 +1,5 @@
 #include "argparse.hpp"
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 
 


### PR DESCRIPTION
In the past PR I missed updating all the included headers for the standard tests. This finishes updating from CL/sycl --> sycl/sycl.