### PR TITLE
Updates to SLM test

### DIFF
--- a/advanced_inferno/1_slm.cpp
+++ b/advanced_inferno/1_slm.cpp
@@ -4,12 +4,20 @@
 #include <sycl/sycl.hpp>
 #include "argparse.hpp"
 
+int get_values( int * A_ptr, int global_range, int local_range, int x, int y ) {
+  if( y == 0 || y == (local_range-1)) {
+    return 0;
+  }
+  return A_ptr[std::clamp(0, (x - 1), global_range-1)] + A_ptr[x] +
+    A_ptr[std::clamp(0, (x + 1), global_range-1)];
+}
+
 int main(int argc, char **argv) {
   //  _                ___
   // |_) _. ._ _  _     |  ._  ._     _|_
   // |  (_| | _> (/_   _|_ | | |_) |_| |_
   //
-  argparse::ArgumentParser program("3_nd_range");
+  argparse::ArgumentParser program("1_slm");
 
   program.add_argument("-g", "--global")
       .help("Global Range")
@@ -31,38 +39,45 @@ int main(int argc, char **argv) {
 
   const auto global_range = program.get<int>("-g");
   const auto local_range = program.get<int>("-l");
+  
+  sycl::queue Q;
+  
+  size_t local_mem_size = Q.get_device().get_info<sycl::info::device::local_mem_size>();
+  std::cout << "Local Memory Size Per Workgroup: " << local_mem_size << " bytes" << std::endl;
 
   //    __                                                           
   //   (_  |_   _. ._ _    |   _   _  _. |   |\/|  _  ._ _   _  ._   
   //   __) | | (_| | (/_   |_ (_) (_ (_| |   |  | (/_ | | | (_) | \/ 
   //                                                              /  
-  sycl::queue Q;
 
   // Create custom shared usm allocator and use it
-  sycl::usm_allocator<float, sycl::usm::alloc::shared> allocator(Q);
-  std::vector<float, decltype(allocator)> A(global_range, allocator);
+  sycl::usm_allocator<int, sycl::usm::alloc::shared> allocator(Q);
+  std::vector<int, decltype(allocator)> A(global_range, allocator);
   std::iota(A.begin(), A.end(), 0);
-
-  for (auto i : A) std::cout << i << ' ';
-  std::cout << std::endl;
-
+  std::vector<int> A_ref(A.begin(), A.end());
+  
   auto A_ptr = A.data();
   Q.submit([&](sycl::handler &cgh) {
-     sycl::local_accessor<float> tmp_wg(sycl::range<1>(local_range), cgh);
+    // note that here we allocate all available SLM. if we increase this by 1 it will fail at
+    // runtime with an UR_RESULT_ERROR_OUT_OF_RESOURCES error
+    sycl::local_accessor<int> tmp_wg(sycl::range<1>(local_mem_size / sizeof(int)), cgh);
 
-     cgh.parallel_for(
+    cgh.parallel_for(
          sycl::nd_range<1>(global_range, local_range), [=](sycl::nd_item<1> i) {
            int x = i.get_global_linear_id();
            int y = i.get_local_linear_id();
-           tmp_wg[y] = (A_ptr[std::clamp(0, (x - 1), local_range)] + A_ptr[x] +
-                     A_ptr[std::clamp(0, (x + 1), local_range)]);
+           tmp_wg[y] = get_values( A_ptr, global_range, local_range, x,y);
            i.barrier();
-           A_ptr[x] = tmp_wg[y];
+	   A_ptr[x] = tmp_wg[y];
          });
    }).wait();
 
-  for (auto i : A) std::cout << i << ' ';
-  std::cout << std::endl;
-
+  for (int i=0;i<global_range;i++) {
+    int ref = get_values( A_ref.data(), global_range, local_range, i, i %local_range);
+    assert( A[i] == ref);
+     
+  }
+  printf("Success!\n");
+  
   return 0;
 }


### PR DESCRIPTION
This was done with @TApplencourt . This updates the SLM test to avoid a race condition that previously occurred on the boundaries of groups, since the group barrier only applies inside a group and not between groups, but the computation spanned groups. This changes it so that the boundaries between groups are 0.